### PR TITLE
Load comments from Datastore

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  private List<String> demoComments = new ArrayList<String>();
+  List<String> demoComments = new ArrayList<String>();
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -42,6 +42,7 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
+    List<String> demoComments = new ArrayList<String>();
     for(Entity entity : results.asIterable()) {
       String content = (String) entity.getProperty("content");
       demoComments.add(content);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -33,20 +33,20 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  private String commentText;
-  private long commentTime;
+  private static final String CONTENT_TEXT_PROPERTY_NAME ="content";
+  private static final String TIMESTAMP_TEXT_PROPERTY_NAME = "timestamp";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("comment").addSort("timestamp", SortDirection.DESCENDING);
+    Query query = new Query("comment").addSort(TIMESTAMP_TEXT_PROPERTY_NAME, SortDirection.DESCENDING);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
     List<String> demoComments = new ArrayList<String>();
     for(Entity entity : results.asIterable()) {
-      String content = (String) entity.getProperty("content");
-      demoComments.add(content);
+      String commentContent = (String) entity.getProperty(CONTENT_TEXT_PROPERTY_NAME);
+      demoComments.add(commentContent);
     }
 
     Gson gson = new Gson();
@@ -57,12 +57,12 @@ public class DataServlet extends HttpServlet {
   }
 
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    commentText = request.getParameter("comment");
-    commentTime = System.currentTimeMillis();
+    String commentText = request.getParameter("write-comment");
+    long commentTime = System.currentTimeMillis();
 
     Entity commentEntity = new Entity("comment");
-    commentEntity.setProperty("content", commentText);
-    commentEntity.setProperty("timestamp", commentTime);
+    commentEntity.setProperty(CONTENT_TEXT_PROPERTY_NAME, commentText);
+    commentEntity.setProperty(TIMESTAMP_TEXT_PROPERTY_NAME, commentTime);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -33,7 +33,8 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  List<String> demoComments = new ArrayList<String>();
+  private String commentText;
+  private long commentTime;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -56,8 +57,8 @@ public class DataServlet extends HttpServlet {
   }
 
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String commentText = request.getParameter("comment");
-    long commentTime = System.currentTimeMillis();
+    commentText = request.getParameter("comment");
+    commentTime = System.currentTimeMillis();
 
     Entity commentEntity = new Entity("comment");
     commentEntity.setProperty("content", commentText);

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -30,11 +30,11 @@
       <form action="/data" method="POST">
 
         <p>> Add a comment</p>
-        <input type="text" name="comment"><br>
+        <input type="text" name="write-comment"><br>
         <input type="submit">
 
       </form>
-      <ul id="comments"></ul>
+      <ul id="comment-section"></ul>
     </div>
   </body>
 </html>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -46,7 +46,6 @@ function responseHandler(response) {
 function addCommentsToDom(comments) {
   const commentsContainer = document.getElementById('comments');
   
-  commentsContainer.innerText = '';
   for(let i = 0; i < comments.length; i++) {
     commentsContainer.appendChild(
       createListElement(comments[i]));

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -44,7 +44,7 @@ function responseHandler(response) {
  * @param {JSON} comments parsed JSON from original Promise
  */
 function addCommentsToDom(comments) {
-  const commentsContainer = document.getElementById('comments');
+  const commentsContainer = document.getElementById('comment-section');
   
   for(let i = 0; i < comments.length; i++) {
     commentsContainer.appendChild(


### PR DESCRIPTION
Comments are now stored and loaded via query in Datastore for persistence. There is currently a bug where comments previously loaded still display, leading to duplicates. This will be fixed in the next PR.