### PR TITLE
Add feature for user to choose how many comments to display, defaulting to max number with no input

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -43,7 +43,7 @@ public class DataServlet extends HttpServlet {
     Query query = new Query("comment").addSort(TIMESTAMP_TEXT_PROPERTY_NAME, SortDirection.DESCENDING);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    PreparedQuery results = datastore.prepare(query).;
+    PreparedQuery results = datastore.prepare(query);
 
     List<String> demoComments = new ArrayList<String>();
     for(Entity entity : results.asIterable()) {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -38,15 +38,21 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    int numCommentsDisplayed = Integer.parseInt(request.getParameter("numCommentsDisplayed"));
+
     Query query = new Query("comment").addSort(TIMESTAMP_TEXT_PROPERTY_NAME, SortDirection.DESCENDING);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    PreparedQuery results = datastore.prepare(query);
+    PreparedQuery results = datastore.prepare(query).;
 
     List<String> demoComments = new ArrayList<String>();
     for(Entity entity : results.asIterable()) {
       String commentContent = (String) entity.getProperty(CONTENT_TEXT_PROPERTY_NAME);
       demoComments.add(commentContent);
+
+      if(demoComments.size() == numCommentsDisplayed)  {
+        break;
+      }
     }
 
     Gson gson = new Gson();

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -27,14 +27,17 @@
       <p> > |_ Javascript</p>
       <p> ></p>
       <p> > Click <a href="http://www.linkedin.com/in/miguelfabrigas">here</a> to see my resume</p>
-      <form action="/data" method="POST">
 
-        <p>> Add a comment</p>
+      <form action="/data" method="POST">
+        <p> > Write a comment</p>
         <input type="text" name="write-comment"><br>
         <input type="submit">
-
       </form>
+
       <ul id="comment-section"></ul>
+
+      <p> > Select number of comments to display (between 1-10)</p>
+      <input type="number" name="num-comments" min=1 max=10 onchange="loadComments(this.value)">  
     </div>
   </body>
 </html>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -14,6 +14,7 @@
 
 let cursor = true;
 const speed = 250;
+const MAX_COMMENTS = 10;
 
 setInterval(() => {
   if(cursor) {
@@ -29,6 +30,11 @@ setInterval(() => {
  * @param {number} numCommentsDisplayed number of comments to display
  */
 function loadComments(numCommentsDisplayed) {
+  if(numCommentsDisplayed === undefined) {
+    numCommentsDisplayed = MAX_COMMENTS;
+    console.log(numCommentsDisplayed);
+  }
+
   fetch('/data?numCommentsDisplayed=' + numCommentsDisplayed).then(response => response.json()).then((commentList) => {
     const commentsContainer = document.getElementById('comment-section');
     commentsContainer.innerHTML = '';

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -25,9 +25,13 @@ setInterval(() => {
   }
 }, speed);
 
-function loadComments() {
-  fetch('/data').then(response => response.json()).then((commentList) => {
+/**
+ * @param {number} numCommentsDisplayed number of comments to display
+ */
+function loadComments(numCommentsDisplayed) {
+  fetch('/data?numCommentsDisplayed=' + numCommentsDisplayed).then(response => response.json()).then((commentList) => {
     const commentsContainer = document.getElementById('comment-section');
+    commentsContainer.innerHTML = '';
     commentList.forEach((comment) => {
       commentsContainer.appendChild(createListElement(comment));
     })

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -32,7 +32,6 @@ setInterval(() => {
 function loadComments(numCommentsDisplayed) {
   if(numCommentsDisplayed === undefined) {
     numCommentsDisplayed = MAX_COMMENTS;
-    console.log(numCommentsDisplayed);
   }
 
   fetch('/data?numCommentsDisplayed=' + numCommentsDisplayed).then(response => response.json()).then((commentList) => {


### PR DESCRIPTION
User selects between 1 and 10 comments to display, upon which the page reloads with the specified number of comments. Without input e.g. immediately after adding comment or upon first load of page, the number of comments displayed defaults to max number of 10.